### PR TITLE
Add pymrio package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly >= 4.12.0
 tabulate >= 0.8.9
 openpyxl >= 3.0.6
 IPython >= 7.22.0
+pymrio


### PR DESCRIPTION


**TLDR**
I tried to follow the Mario set up instruction and I believe the pymrio package is missing from requirements.txt.
I am using this as an opportunity to try my first pull request on the MARIO repo just to make sure everything works properly. 

**REPRO**

i tried to install MARIO and then run a simple script using it.
Here is the script I tried: https://gist.github.com/AAmedeo/fdeb1f74413d109d3f2727fa1116e687

This is what happened before adding pymrio to requirements.txt
```
afa@afa-mbp MARIO % rm -r venv
afa@afa-mbp MARIO % python3 -m venv venv
afa@afa-mbp MARIO % source ./venv/bin/activate
(venv) afa@afa-mbp MARIO % pip3 install -r requirements.txt
(venv) afa@afa-mbp MARIO % python3 mario_hello_world.py
Traceback (most recent call last):
  File "mario_hello_world.py", line 1, in <module>
    import mario
  File "/Users/afa/Desktop/MARIO/mario/__init__.py", line 48, in <module>
    from mario.core.AttrData import Database
  File "/Users/afa/Desktop/MARIO/mario/core/AttrData.py", line 91, in <module>
    from mario.core.CoreIO import CoreModel
  File "/Users/afa/Desktop/MARIO/mario/core/CoreIO.py", line 15, in <module>
    from mario.tools.tableparser import dataframe_parser
  File "/Users/afa/Desktop/MARIO/mario/tools/tableparser.py", line 48, in <module>
    import pymrio
ModuleNotFoundError: No module named 'pymrio'
```

This is what happened after adding pymrio to requirements.txt
```
afa@afa-mbp MARIO % rm -r venv
afa@afa-mbp MARIO % python3 -m venv venv
afa@afa-mbp MARIO % source ./venv/bin/activate
(venv) afa@afa-mbp MARIO % pip3 install -r requirements.txt
(venv) afa@afa-mbp MARIO % python3 mario_hello_world.py
cvxpy module is not installed in your system. This will raise problems in some of the abilities of MARIO
name = IOT test
table = IOT
scenarios = ['baseline']
Factor of production = 3
Satellite account = 4
Consumption category = 1
Region = 2
Sector = 6

name = SUT test
table = SUT
scenarios = ['baseline']
Activity = 6
Commodity = 6
Factor of production = 3
Satellite account = 1
Consumption category = 1
Region = 2

['RoW', 'Italy']
['Taxes', 'Wages', 'Capital']
```

